### PR TITLE
Support MCP 2025-11-25 protocol

### DIFF
--- a/src/mcp/manifest.ts
+++ b/src/mcp/manifest.ts
@@ -9,8 +9,8 @@ export const SERVER_MANIFEST = {
   version: "2.0.0",
   description:
     "Ultra-modern MCP server providing AI agents with comprehensive access to Apple's complete developer documentation using advanced RAG technology.",
-  protocolVersion: "2025-06-18",
-  supportedVersions: ["2025-06-18", "2025-03-26"],
+  protocolVersion: "2025-11-25",
+  supportedVersions: ["2025-11-25", "2025-06-18", "2025-03-26"],
   capabilities: {
     tools: { listChanged: true },
     logging: {},
@@ -43,6 +43,6 @@ export const SERVER_MANIFEST = {
 export const HEALTH_STATUS = {
   status: "healthy",
   version: "2.0.0",
-  protocol: "2025-06-18",
-  supportedVersions: ["2025-06-18", "2025-03-26"],
+  protocol: "2025-11-25",
+  supportedVersions: ["2025-11-25", "2025-06-18", "2025-03-26"],
 } as const;

--- a/src/mcp/protocol-handler.ts
+++ b/src/mcp/protocol-handler.ts
@@ -60,8 +60,12 @@ export const MCP_ERROR_CODES = {
   RATE_LIMIT_EXCEEDED: -32003,
 } as const;
 
-export const MCP_PROTOCOL_VERSION = "2025-03-26";
-export const SUPPORTED_MCP_VERSIONS = ["2025-06-18", "2025-03-26"] as const;
+export const MCP_PROTOCOL_VERSION = "2025-11-25";
+export const SUPPORTED_MCP_VERSIONS = [
+  "2025-11-25",
+  "2025-06-18",
+  "2025-03-26",
+] as const;
 
 // Standard CORS headers for all responses
 const CORS_HEADERS = {


### PR DESCRIPTION
### Motivation
- Update the server to advertise and accept the newest MCP protocol so clients can negotiate `2025-11-25` while preserving backward compatibility with older versions.

### Description
- Bumped `MCP_PROTOCOL_VERSION` to `"2025-11-25"` and extended `SUPPORTED_MCP_VERSIONS` to include `"2025-11-25"` in `src/mcp/protocol-handler.ts`.
- Aligned `SERVER_MANIFEST.protocolVersion` and `HEALTH_STATUS.protocol` and their `supportedVersions` arrays to include `"2025-11-25"` in `src/mcp/manifest.ts`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69857f22810c8333acc777c4e15d23c9)