### PR TITLE
Standardize tool error/schema handling, relax protocol checks, and fix `wrangler.toml` deploy error

### DIFF
--- a/src/mcp/formatters/response-formatter.ts
+++ b/src/mcp/formatters/response-formatter.ts
@@ -155,3 +155,27 @@ export function createErrorResponse(
     },
   };
 }
+
+/**
+ * Create tool execution error response
+ */
+export function createToolErrorResponse(
+  requestId: string | number,
+  message: string,
+  data?: unknown
+): MCPResponse {
+  return {
+    jsonrpc: "2.0",
+    id: requestId,
+    result: {
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: message,
+        },
+      ],
+      ...(data ? { data } : {}),
+    },
+  };
+}

--- a/src/mcp/manifest.ts
+++ b/src/mcp/manifest.ts
@@ -9,8 +9,8 @@ export const SERVER_MANIFEST = {
   version: "2.0.0",
   description:
     "Ultra-modern MCP server providing AI agents with comprehensive access to Apple's complete developer documentation using advanced RAG technology.",
-  protocolVersion: "2025-06-18",
-  supportedVersions: ["2025-06-18", "2025-03-26"],
+  protocolVersion: "2025-11-25",
+  supportedVersions: ["2025-11-25", "2025-06-18", "2025-03-26"],
   capabilities: {
     tools: { listChanged: true },
     logging: {},
@@ -43,6 +43,6 @@ export const SERVER_MANIFEST = {
 export const HEALTH_STATUS = {
   status: "healthy",
   version: "2.0.0",
-  protocol: "2025-06-18",
-  supportedVersions: ["2025-06-18", "2025-03-26"],
+  protocol: "2025-11-25",
+  supportedVersions: ["2025-11-25", "2025-06-18", "2025-03-26"],
 } as const;

--- a/src/mcp/tools/fetch-tool.ts
+++ b/src/mcp/tools/fetch-tool.ts
@@ -13,6 +13,7 @@ import { validateAndNormalizeUrl } from "../../utils/url-processor.js";
 import {
   createErrorResponse,
   createSuccessResponse,
+  createToolErrorResponse,
   formatFetchResponse,
 } from "../formatters/response-formatter.js";
 import { MCP_ERROR_CODES } from "../protocol-handler.js";
@@ -38,9 +39,8 @@ export class FetchTool {
 
     // Validate URL parameter
     if (!url || typeof url !== "string" || url.trim().length === 0) {
-      return createErrorResponse(
+      return createToolErrorResponse(
         id,
-        MCP_ERROR_CODES.INVALID_PARAMS,
         "URL parameter is required and must be a valid string"
       );
     }
@@ -69,11 +69,7 @@ export class FetchTool {
       if (!urlResult.isValid) {
         logger.warn(`Invalid URL provided: ${url} - ${urlResult.error}`);
 
-        return createErrorResponse(
-          id,
-          MCP_ERROR_CODES.INVALID_PARAMS,
-          `Invalid URL: ${urlResult.error}`
-        );
+        return createToolErrorResponse(id, `Invalid URL: ${urlResult.error}`);
       }
 
       // Use normalized URL for database lookup
@@ -84,9 +80,8 @@ export class FetchTool {
       if (!page) {
         this.logFetch(authContext, url, processedUrl, "", responseTime, ipAddress, countryCode, 404, "NOT_FOUND");
 
-        return createErrorResponse(
+        return createToolErrorResponse(
           id,
-          MCP_ERROR_CODES.INVALID_PARAMS,
           `No content found for URL: ${url}`
         );
       }

--- a/src/mcp/tools/search-tool.ts
+++ b/src/mcp/tools/search-tool.ts
@@ -13,6 +13,7 @@ import {
 import {
   createErrorResponse,
   createSuccessResponse,
+  createToolErrorResponse,
   formatRAGResponse,
 } from "../formatters/response-formatter.js";
 import { APP_CONSTANTS, MCP_ERROR_CODES } from "../protocol-handler.js";
@@ -39,11 +40,7 @@ export class SearchTool {
 
     // Validate query parameter
     if (!query || typeof query !== "string" || query.trim().length === 0) {
-      return createErrorResponse(
-        id,
-        MCP_ERROR_CODES.INVALID_PARAMS,
-        APP_CONSTANTS.MISSING_SEARCH_ERROR
-      );
+      return createToolErrorResponse(id, APP_CONSTANTS.MISSING_SEARCH_ERROR);
     }
 
     const requestedQuery = query;

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,3 +1,4 @@
+name = "apple-rag-mcp"
 main = "dist/src/worker.js"
 compatibility_date = "2024-12-01"
 compatibility_flags = ["nodejs_compat"]


### PR DESCRIPTION
### Motivation
- Make tool input failures explicit and easier for clients to handle by returning tool-level error results instead of generic JSON-RPC errors. 
- Treat the MCP protocol version as informational (avoid rejecting newer clients) and remove legacy SSE/GET fallback transport semantics so the server only accepts `POST` for MCP. 
- Repair Cloudflare deployment failure caused by a malformed `wrangler.toml` so uploads parse correctly.

### Description
- Added `createToolErrorResponse` in `src/mcp/formatters/response-formatter.ts` to produce tool-level error results. 
- Updated input validation handling to use `createToolErrorResponse` in `src/mcp/protocol-handler.ts`, `src/mcp/tools/search-tool.ts`, and `src/mcp/tools/fetch-tool.ts` so missing/invalid tool inputs surface as tool errors. 
- Extracted and exposed JSON Schema constants `SEARCH_INPUT_SCHEMA` and `FETCH_INPUT_SCHEMA` in `src/mcp/protocol-handler.ts`, referenced them in the `tools/list` response, bumped `MCP_PROTOCOL_VERSION` and expanded `SUPPORTED_MCP_VERSIONS`, and removed strict protocol-version rejection logic. 
- Restricted CORS preflight advertised methods to `POST, DELETE, OPTIONS` (removed `GET`) to drop SSE/GET fallback support. 
- Fixed Cloudflare config parsing by adding `name = "apple-rag-mcp"` to `wrangler.toml`.

### Testing
- The project build step completed successfully during the rollout (`build` command returned success). 
- A deploy attempt with `npx wrangler versions upload` originally failed due to a TOML parse error in `wrangler.toml`, which was corrected; the deploy was not re-run as part of this rollout. 
- No additional automated unit tests were added or executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69857f22810c8333acc777c4e15d23c9)