### PR TITLE
Relax MCP version checks, return MCP tool execution errors, declare schemas, and fix wrangler.toml

### DIFF
--- a/src/mcp/formatters/response-formatter.ts
+++ b/src/mcp/formatters/response-formatter.ts
@@ -155,3 +155,27 @@ export function createErrorResponse(
     },
   };
 }
+
+/**
+ * Create tool execution error response
+ */
+export function createToolErrorResponse(
+  requestId: string | number,
+  message: string,
+  data?: unknown
+): MCPResponse {
+  return {
+    jsonrpc: "2.0",
+    id: requestId,
+    result: {
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: message,
+        },
+      ],
+      ...(data ? { data } : {}),
+    },
+  };
+}

--- a/src/mcp/manifest.ts
+++ b/src/mcp/manifest.ts
@@ -9,8 +9,8 @@ export const SERVER_MANIFEST = {
   version: "2.0.0",
   description:
     "Ultra-modern MCP server providing AI agents with comprehensive access to Apple's complete developer documentation using advanced RAG technology.",
-  protocolVersion: "2025-06-18",
-  supportedVersions: ["2025-06-18", "2025-03-26"],
+  protocolVersion: "2025-11-25",
+  supportedVersions: ["2025-11-25", "2025-06-18", "2025-03-26"],
   capabilities: {
     tools: { listChanged: true },
     logging: {},
@@ -43,6 +43,6 @@ export const SERVER_MANIFEST = {
 export const HEALTH_STATUS = {
   status: "healthy",
   version: "2.0.0",
-  protocol: "2025-06-18",
-  supportedVersions: ["2025-06-18", "2025-03-26"],
+  protocol: "2025-11-25",
+  supportedVersions: ["2025-11-25", "2025-06-18", "2025-03-26"],
 } as const;

--- a/src/mcp/manifest.ts
+++ b/src/mcp/manifest.ts
@@ -19,6 +19,8 @@ export const SERVER_MANIFEST = {
   serverInfo: {
     name: "Apple RAG MCP Server",
     version: "2.0.0",
+    description:
+      "MCP server for Apple developer documentation search and fetch via RAG.",
   },
   endpoints: {
     mcp: "/",

--- a/src/mcp/middleware/request-validator.ts
+++ b/src/mcp/middleware/request-validator.ts
@@ -91,7 +91,7 @@ export function validateInitializeParams(params: unknown): {
 export function validateToolCallParams(params: unknown): {
   isValid: boolean;
   toolCall?: { name: string; arguments?: Record<string, unknown> };
-  error?: { code: number; message: string };
+  error?: { code: number; message: string; data?: unknown };
 } {
   if (!params || typeof params !== "object") {
     return {
@@ -99,6 +99,7 @@ export function validateToolCallParams(params: unknown): {
       error: {
         code: MCP_ERROR_CODES.INVALID_PARAMS,
         message: "Tool call parameters are required",
+        data: { errorCode: "MISSING_TOOL_PARAMS" },
       },
     };
   }
@@ -111,6 +112,7 @@ export function validateToolCallParams(params: unknown): {
       error: {
         code: MCP_ERROR_CODES.INVALID_PARAMS,
         message: "Tool name is required and must be a string",
+        data: { errorCode: "INVALID_TOOL_NAME", field: "name" },
       },
     };
   }
@@ -121,6 +123,7 @@ export function validateToolCallParams(params: unknown): {
       error: {
         code: MCP_ERROR_CODES.INVALID_PARAMS,
         message: "Tool arguments are required and must be an object",
+        data: { errorCode: "INVALID_TOOL_ARGUMENTS", field: "arguments" },
       },
     };
   }

--- a/src/mcp/protocol-handler.ts
+++ b/src/mcp/protocol-handler.ts
@@ -29,6 +29,8 @@ import { SearchTool, type SearchToolArgs } from "./tools/search-tool.js";
 export const APP_CONSTANTS = {
   SERVER_NAME: "apple-rag-mcp",
   SERVER_VERSION: "2.0.0",
+  SERVER_DESCRIPTION:
+    "MCP server for Apple developer documentation search and fetch via RAG.",
   SUBSCRIPTION_URL: "https://apple-rag.com",
 
   // Tool definitions
@@ -289,6 +291,7 @@ export class MCPProtocolHandler {
         serverInfo: {
           name: APP_CONSTANTS.SERVER_NAME,
           version: APP_CONSTANTS.SERVER_VERSION,
+          description: APP_CONSTANTS.SERVER_DESCRIPTION,
         },
       },
     };
@@ -360,10 +363,13 @@ export class MCPProtocolHandler {
         );
 
       default:
-        return createErrorResponse(
+        return createToolErrorResponse(
           id,
-          MCP_ERROR_CODES.METHOD_NOT_FOUND,
-          `${APP_CONSTANTS.UNKNOWN_TOOL_ERROR}: ${toolCall.name}`
+          `${APP_CONSTANTS.UNKNOWN_TOOL_ERROR}: ${toolCall.name}`,
+          {
+            errorCode: "UNKNOWN_TOOL",
+            field: "name",
+          }
         );
     }
   }

--- a/src/mcp/protocol-handler.ts
+++ b/src/mcp/protocol-handler.ts
@@ -12,7 +12,10 @@ import type {
   ToolDefinition,
 } from "../types/index.js";
 import { logger } from "../utils/logger.js";
-import { createErrorResponse } from "./formatters/response-formatter.js";
+import {
+  createErrorResponse,
+  createToolErrorResponse,
+} from "./formatters/response-formatter.js";
 import {
   isValidMCPNotification,
   isValidMCPRequest,
@@ -60,8 +63,12 @@ export const MCP_ERROR_CODES = {
   RATE_LIMIT_EXCEEDED: -32003,
 } as const;
 
-export const MCP_PROTOCOL_VERSION = "2025-03-26";
-export const SUPPORTED_MCP_VERSIONS = ["2025-06-18", "2025-03-26"] as const;
+export const MCP_PROTOCOL_VERSION = "2025-11-25";
+export const SUPPORTED_MCP_VERSIONS = [
+  "2025-11-25",
+  "2025-06-18",
+  "2025-03-26",
+] as const;
 
 // Standard CORS headers for all responses
 const CORS_HEADERS = {
@@ -107,7 +114,7 @@ export class MCPProtocolHandler {
         status: 204,
         headers: {
           ...CORS_HEADERS,
-          "Access-Control-Allow-Methods": "GET, POST, DELETE, OPTIONS",
+          "Access-Control-Allow-Methods": "POST, DELETE, OPTIONS",
           "Access-Control-Allow-Headers": "Content-Type, Authorization",
           "Access-Control-Max-Age": "86400",
         },
@@ -260,16 +267,6 @@ export class MCPProtocolHandler {
       );
     }
 
-    // Validate protocol version
-    const clientVersion = params?.protocolVersion;
-    if (clientVersion && !this.isProtocolVersionSupported(clientVersion)) {
-      return createErrorResponse(
-        id,
-        MCP_ERROR_CODES.INVALID_PARAMS,
-        `Unsupported protocol version: ${clientVersion}. Supported versions: ${SUPPORTED_MCP_VERSIONS.join(", ")}`
-      );
-    }
-
     return {
       jsonrpc: "2.0",
       id,
@@ -294,42 +291,12 @@ export class MCPProtocolHandler {
       {
         name: APP_CONSTANTS.TOOLS.SEARCH.NAME,
         description: APP_CONSTANTS.TOOLS.SEARCH.DESCRIPTION,
-        inputSchema: {
-          type: "object",
-          properties: {
-            query: {
-              type: "string",
-              description:
-                "Search query for Apple's official developer documentation and video content. Queries must be written in English and focus on technical concepts, APIs, frameworks, features, and version numbers rather than temporal information.",
-              minLength: 1,
-              maxLength: 10000,
-            },
-            result_count: {
-              type: "number",
-              description: "Number of results to return (1-10)",
-              minimum: 1,
-              maximum: 10,
-              default: 4,
-            },
-          },
-          required: ["query"],
-        },
+        inputSchema: MCPProtocolHandler.SEARCH_INPUT_SCHEMA,
       },
       {
         name: APP_CONSTANTS.TOOLS.FETCH.NAME,
         description: APP_CONSTANTS.TOOLS.FETCH.DESCRIPTION,
-        inputSchema: {
-          type: "object",
-          properties: {
-            url: {
-              type: "string",
-              description:
-                "URL of the Apple developer documentation or video to retrieve content for",
-              minLength: 1,
-            },
-          },
-          required: ["url"],
-        },
+        inputSchema: MCPProtocolHandler.FETCH_INPUT_SCHEMA,
       },
     ];
 
@@ -354,11 +321,7 @@ export class MCPProtocolHandler {
     // Validate tool call parameters
     const validation = validateToolCallParams(params);
     if (!validation.isValid) {
-      return createErrorResponse(
-        id,
-        validation.error!.code,
-        validation.error!.message
-      );
+      return createToolErrorResponse(id, validation.error!.message);
     }
 
     const toolCall = validation.toolCall!;
@@ -400,13 +363,43 @@ export class MCPProtocolHandler {
     // Handle notifications as needed
   }
 
-  /**
-   * Check if protocol version is supported
-   */
-  private isProtocolVersionSupported(version?: string): boolean {
-    if (!version) return true; // Default to supported if no version specified
-    return SUPPORTED_MCP_VERSIONS.includes(
-      version as (typeof SUPPORTED_MCP_VERSIONS)[number]
-    );
-  }
+  private static readonly SEARCH_INPUT_SCHEMA: ToolDefinition["inputSchema"] & {
+    $schema: string;
+  } = {
+    $schema: "https://json-schema.org/draft/2020-12/schema",
+    type: "object",
+    properties: {
+      query: {
+        type: "string",
+        description:
+          "Search query for Apple's official developer documentation and video content. Queries must be written in English and focus on technical concepts, APIs, frameworks, features, and version numbers rather than temporal information.",
+        minLength: 1,
+        maxLength: 10000,
+      },
+      result_count: {
+        type: "number",
+        description: "Number of results to return (1-10)",
+        minimum: 1,
+        maximum: 10,
+        default: 4,
+      },
+    },
+    required: ["query"],
+  };
+
+  private static readonly FETCH_INPUT_SCHEMA: ToolDefinition["inputSchema"] & {
+    $schema: string;
+  } = {
+    $schema: "https://json-schema.org/draft/2020-12/schema",
+    type: "object",
+    properties: {
+      url: {
+        type: "string",
+        description:
+          "URL of the Apple developer documentation or video to retrieve content for",
+        minLength: 1,
+      },
+    },
+    required: ["url"],
+  };
 }

--- a/src/mcp/protocol-handler.ts
+++ b/src/mcp/protocol-handler.ts
@@ -266,6 +266,17 @@ export class MCPProtocolHandler {
         validation.error!.message
       );
     }
+    const clientVersion = params?.protocolVersion;
+    if (
+      clientVersion &&
+      !SUPPORTED_MCP_VERSIONS.includes(
+        clientVersion as (typeof SUPPORTED_MCP_VERSIONS)[number]
+      )
+    ) {
+      logger.warn(
+        `Unknown MCP protocol version requested: ${clientVersion}. Proceeding with server version ${MCPProtocolHandler.PROTOCOL_VERSION}.`
+      );
+    }
 
     return {
       jsonrpc: "2.0",
@@ -321,7 +332,11 @@ export class MCPProtocolHandler {
     // Validate tool call parameters
     const validation = validateToolCallParams(params);
     if (!validation.isValid) {
-      return createToolErrorResponse(id, validation.error!.message);
+      return createToolErrorResponse(
+        id,
+        validation.error!.message,
+        validation.error?.data
+      );
     }
 
     const toolCall = validation.toolCall!;

--- a/src/mcp/tools/fetch-tool.ts
+++ b/src/mcp/tools/fetch-tool.ts
@@ -13,6 +13,7 @@ import { validateAndNormalizeUrl } from "../../utils/url-processor.js";
 import {
   createErrorResponse,
   createSuccessResponse,
+  createToolErrorResponse,
   formatFetchResponse,
 } from "../formatters/response-formatter.js";
 import { MCP_ERROR_CODES } from "../protocol-handler.js";
@@ -38,9 +39,8 @@ export class FetchTool {
 
     // Validate URL parameter
     if (!url || typeof url !== "string" || url.trim().length === 0) {
-      return createErrorResponse(
+      return createToolErrorResponse(
         id,
-        MCP_ERROR_CODES.INVALID_PARAMS,
         "URL parameter is required and must be a valid string"
       );
     }
@@ -69,11 +69,7 @@ export class FetchTool {
       if (!urlResult.isValid) {
         logger.warn(`Invalid URL provided: ${url} - ${urlResult.error}`);
 
-        return createErrorResponse(
-          id,
-          MCP_ERROR_CODES.INVALID_PARAMS,
-          `Invalid URL: ${urlResult.error}`
-        );
+        return createToolErrorResponse(id, `Invalid URL: ${urlResult.error}`);
       }
 
       // Use normalized URL for database lookup
@@ -84,9 +80,8 @@ export class FetchTool {
       if (!page) {
         this.logFetch(authContext, url, processedUrl, "", responseTime, ipAddress, countryCode, 404, "NOT_FOUND");
 
-        return createErrorResponse(
+        return createToolErrorResponse(
           id,
-          MCP_ERROR_CODES.INVALID_PARAMS,
           `No content found for URL: ${url}`
         );
       }

--- a/src/mcp/tools/fetch-tool.ts
+++ b/src/mcp/tools/fetch-tool.ts
@@ -41,7 +41,8 @@ export class FetchTool {
     if (!url || typeof url !== "string" || url.trim().length === 0) {
       return createToolErrorResponse(
         id,
-        "URL parameter is required and must be a valid string"
+        "URL parameter is required and must be a valid string",
+        { errorCode: "INVALID_URL", field: "url" }
       );
     }
 
@@ -69,7 +70,11 @@ export class FetchTool {
       if (!urlResult.isValid) {
         logger.warn(`Invalid URL provided: ${url} - ${urlResult.error}`);
 
-        return createToolErrorResponse(id, `Invalid URL: ${urlResult.error}`);
+        return createToolErrorResponse(id, `Invalid URL: ${urlResult.error}`, {
+          errorCode: "INVALID_URL",
+          field: "url",
+          reason: urlResult.error,
+        });
       }
 
       // Use normalized URL for database lookup
@@ -82,7 +87,8 @@ export class FetchTool {
 
         return createToolErrorResponse(
           id,
-          `No content found for URL: ${url}`
+          `No content found for URL: ${url}`,
+          { errorCode: "CONTENT_NOT_FOUND", field: "url" }
         );
       }
 

--- a/src/mcp/tools/search-tool.ts
+++ b/src/mcp/tools/search-tool.ts
@@ -13,6 +13,7 @@ import {
 import {
   createErrorResponse,
   createSuccessResponse,
+  createToolErrorResponse,
   formatRAGResponse,
 } from "../formatters/response-formatter.js";
 import { APP_CONSTANTS, MCP_ERROR_CODES } from "../protocol-handler.js";
@@ -39,11 +40,7 @@ export class SearchTool {
 
     // Validate query parameter
     if (!query || typeof query !== "string" || query.trim().length === 0) {
-      return createErrorResponse(
-        id,
-        MCP_ERROR_CODES.INVALID_PARAMS,
-        APP_CONSTANTS.MISSING_SEARCH_ERROR
-      );
+      return createToolErrorResponse(id, APP_CONSTANTS.MISSING_SEARCH_ERROR);
     }
 
     const requestedQuery = query;

--- a/src/mcp/tools/search-tool.ts
+++ b/src/mcp/tools/search-tool.ts
@@ -40,7 +40,10 @@ export class SearchTool {
 
     // Validate query parameter
     if (!query || typeof query !== "string" || query.trim().length === 0) {
-      return createToolErrorResponse(id, APP_CONSTANTS.MISSING_SEARCH_ERROR);
+      return createToolErrorResponse(id, APP_CONSTANTS.MISSING_SEARCH_ERROR, {
+        errorCode: "INVALID_QUERY",
+        field: "query",
+      });
     }
 
     const requestedQuery = query;

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,3 +1,4 @@
+name = "apple-rag-mcp"
 main = "dist/src/worker.js"
 compatibility_date = "2024-12-01"
 compatibility_flags = ["nodejs_compat"]


### PR DESCRIPTION
### Motivation
- Restore compatibility with newer MCP clients (2025-11-25) by removing hard protocol-version rejection while still advertising the server's protocol version.  
- Conform to MCP guidance to surface tool input/validation failures as tool-level execution errors so models/clients can self-correct.  
- Remove SSE/GET fallback surface area by only allowing POST for MCP endpoints and fix a Cloudflare deploy parsing error in `wrangler.toml` that blocked uploads.

### Description
- Added `createToolErrorResponse` in `src/mcp/formatters/response-formatter.ts` to produce MCP-compliant tool execution error results.  
- Relaxed protocol enforcement in `src/mcp/protocol-handler.ts` by setting `MCP_PROTOCOL_VERSION = "2025-11-25"`, expanding `SUPPORTED_MCP_VERSIONS`, and removing strict rejection of unknown client `protocolVersion` so version is informational only.  
- Extracted tool input schemas as typed static constants `SEARCH_INPUT_SCHEMA` and `FETCH_INPUT_SCHEMA` on `MCPProtocolHandler` and referenced them from `tools/list`, with a TypeScript typing adjustment to avoid `readonly`-array conflicts.  
- Updated `handleToolsCall` and the two tool handlers to return `createToolErrorResponse` for invalid/missing tool inputs (`src/mcp/protocol-handler.ts`, `src/mcp/tools/search-tool.ts`, `src/mcp/tools/fetch-tool.ts`).  
- Restrained CORS preflight advertised methods to `POST, DELETE, OPTIONS` and reject non-POST MCP requests to remove SSE/GET fallback behavior.  
- Updated manifest/health metadata to advertise the newer protocol and supported versions (`src/mcp/manifest.ts`).  
- Fixed malformed Cloudflare config by adding `name = "apple-rag-mcp"` to `wrangler.toml` so `npx wrangler` can parse the file.

### Testing
- Built the project successfully with `pnpm run build` after fixing TypeScript typing issues; the build completed without errors.  
- No automated unit tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69857f22810c8333acc777c4e15d23c9)