### PR TITLE
Relax MCP version validation, add structured tool errors, update manifest and build fixes

### DIFF
--- a/src/mcp/formatters/response-formatter.ts
+++ b/src/mcp/formatters/response-formatter.ts
@@ -155,3 +155,27 @@ export function createErrorResponse(
     },
   };
 }
+
+/**
+ * Create tool execution error response
+ */
+export function createToolErrorResponse(
+  requestId: string | number,
+  message: string,
+  data?: unknown
+): MCPResponse {
+  return {
+    jsonrpc: "2.0",
+    id: requestId,
+    result: {
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: message,
+        },
+      ],
+      ...(data ? { data } : {}),
+    },
+  };
+}

--- a/src/mcp/manifest.ts
+++ b/src/mcp/manifest.ts
@@ -9,8 +9,8 @@ export const SERVER_MANIFEST = {
   version: "2.0.0",
   description:
     "Ultra-modern MCP server providing AI agents with comprehensive access to Apple's complete developer documentation using advanced RAG technology.",
-  protocolVersion: "2025-06-18",
-  supportedVersions: ["2025-06-18", "2025-03-26"],
+  protocolVersion: "2025-11-25",
+  supportedVersions: ["2025-11-25", "2025-06-18", "2025-03-26"],
   capabilities: {
     tools: { listChanged: true },
     logging: {},
@@ -19,6 +19,8 @@ export const SERVER_MANIFEST = {
   serverInfo: {
     name: "Apple RAG MCP Server",
     version: "2.0.0",
+    description:
+      "MCP server for Apple developer documentation search and fetch via RAG.",
   },
   endpoints: {
     mcp: "/",
@@ -43,6 +45,6 @@ export const SERVER_MANIFEST = {
 export const HEALTH_STATUS = {
   status: "healthy",
   version: "2.0.0",
-  protocol: "2025-06-18",
-  supportedVersions: ["2025-06-18", "2025-03-26"],
+  protocol: "2025-11-25",
+  supportedVersions: ["2025-11-25", "2025-06-18", "2025-03-26"],
 } as const;

--- a/src/mcp/middleware/request-validator.ts
+++ b/src/mcp/middleware/request-validator.ts
@@ -4,10 +4,7 @@
  */
 
 import type { MCPNotification, MCPRequest } from "../../types/index.js";
-import {
-  MCP_ERROR_CODES,
-  SUPPORTED_MCP_VERSIONS,
-} from "../protocol-handler.js";
+import { MCP_ERROR_CODES } from "../protocol-handler.js";
 
 /**
  * Validate MCP request structure
@@ -40,31 +37,6 @@ export function isValidMCPNotification(body: unknown): body is MCPNotification {
 }
 
 /**
- * Validate protocol version
- */
-export function validateProtocolVersion(version?: string): {
-  isValid: boolean;
-  error?: { code: number; message: string };
-} {
-  if (
-    version &&
-    !SUPPORTED_MCP_VERSIONS.includes(
-      version as (typeof SUPPORTED_MCP_VERSIONS)[number]
-    )
-  ) {
-    return {
-      isValid: false,
-      error: {
-        code: MCP_ERROR_CODES.INVALID_PARAMS,
-        message: `Unsupported protocol version: ${version}. Supported versions: ${SUPPORTED_MCP_VERSIONS.join(", ")}`,
-      },
-    };
-  }
-
-  return { isValid: true };
-}
-
-/**
  * Validate initialize parameters
  */
 export function validateInitializeParams(params: unknown): {
@@ -91,7 +63,7 @@ export function validateInitializeParams(params: unknown): {
 export function validateToolCallParams(params: unknown): {
   isValid: boolean;
   toolCall?: { name: string; arguments?: Record<string, unknown> };
-  error?: { code: number; message: string };
+  error?: { code: number; message: string; data?: unknown };
 } {
   if (!params || typeof params !== "object") {
     return {
@@ -99,6 +71,7 @@ export function validateToolCallParams(params: unknown): {
       error: {
         code: MCP_ERROR_CODES.INVALID_PARAMS,
         message: "Tool call parameters are required",
+        data: { errorCode: "MISSING_TOOL_PARAMS" },
       },
     };
   }
@@ -111,6 +84,7 @@ export function validateToolCallParams(params: unknown): {
       error: {
         code: MCP_ERROR_CODES.INVALID_PARAMS,
         message: "Tool name is required and must be a string",
+        data: { errorCode: "INVALID_TOOL_NAME", field: "name" },
       },
     };
   }
@@ -121,6 +95,7 @@ export function validateToolCallParams(params: unknown): {
       error: {
         code: MCP_ERROR_CODES.INVALID_PARAMS,
         message: "Tool arguments are required and must be an object",
+        data: { errorCode: "INVALID_TOOL_ARGUMENTS", field: "arguments" },
       },
     };
   }

--- a/src/mcp/tools/fetch-tool.ts
+++ b/src/mcp/tools/fetch-tool.ts
@@ -13,6 +13,7 @@ import { validateAndNormalizeUrl } from "../../utils/url-processor.js";
 import {
   createErrorResponse,
   createSuccessResponse,
+  createToolErrorResponse,
   formatFetchResponse,
 } from "../formatters/response-formatter.js";
 import { MCP_ERROR_CODES } from "../protocol-handler.js";
@@ -38,10 +39,10 @@ export class FetchTool {
 
     // Validate URL parameter
     if (!url || typeof url !== "string" || url.trim().length === 0) {
-      return createErrorResponse(
+      return createToolErrorResponse(
         id,
-        MCP_ERROR_CODES.INVALID_PARAMS,
-        "URL parameter is required and must be a valid string"
+        "URL parameter is required and must be a valid string",
+        { errorCode: "INVALID_URL", field: "url" }
       );
     }
 
@@ -69,11 +70,11 @@ export class FetchTool {
       if (!urlResult.isValid) {
         logger.warn(`Invalid URL provided: ${url} - ${urlResult.error}`);
 
-        return createErrorResponse(
-          id,
-          MCP_ERROR_CODES.INVALID_PARAMS,
-          `Invalid URL: ${urlResult.error}`
-        );
+        return createToolErrorResponse(id, `Invalid URL: ${urlResult.error}`, {
+          errorCode: "INVALID_URL",
+          field: "url",
+          reason: urlResult.error,
+        });
       }
 
       // Use normalized URL for database lookup
@@ -84,10 +85,10 @@ export class FetchTool {
       if (!page) {
         this.logFetch(authContext, url, processedUrl, "", responseTime, ipAddress, countryCode, 404, "NOT_FOUND");
 
-        return createErrorResponse(
+        return createToolErrorResponse(
           id,
-          MCP_ERROR_CODES.INVALID_PARAMS,
-          `No content found for URL: ${url}`
+          `No content found for URL: ${url}`,
+          { errorCode: "CONTENT_NOT_FOUND", field: "url" }
         );
       }
 

--- a/src/mcp/tools/fetch-tool.ts
+++ b/src/mcp/tools/fetch-tool.ts
@@ -55,7 +55,17 @@ export class FetchTool {
     );
 
     if (!rateLimitResult.allowed) {
-      this.logFetch(authContext, url, url, "", 0, ipAddress, countryCode, 429, "RATE_LIMIT_EXCEEDED");
+      this.logFetch(
+        authContext,
+        url,
+        url,
+        "",
+        0,
+        ipAddress,
+        countryCode,
+        429,
+        "RATE_LIMIT_EXCEEDED"
+      );
 
       return createErrorResponse(
         id,
@@ -83,16 +93,33 @@ export class FetchTool {
       const responseTime = Date.now() - startTime;
 
       if (!page) {
-        this.logFetch(authContext, url, processedUrl, "", responseTime, ipAddress, countryCode, 404, "NOT_FOUND");
-
-        return createToolErrorResponse(
-          id,
-          `No content found for URL: ${url}`,
-          { errorCode: "CONTENT_NOT_FOUND", field: "url" }
+        this.logFetch(
+          authContext,
+          url,
+          processedUrl,
+          "",
+          responseTime,
+          ipAddress,
+          countryCode,
+          404,
+          "NOT_FOUND"
         );
+
+        return createToolErrorResponse(id, `No content found for URL: ${url}`, {
+          errorCode: "CONTENT_NOT_FOUND",
+          field: "url",
+        });
       }
 
-      this.logFetch(authContext, url, processedUrl, page.id, responseTime, ipAddress, countryCode);
+      this.logFetch(
+        authContext,
+        url,
+        processedUrl,
+        page.id,
+        responseTime,
+        ipAddress,
+        countryCode
+      );
 
       // Format response with professional styling
       const formattedContent = formatFetchResponse(
@@ -106,7 +133,17 @@ export class FetchTool {
 
       return createSuccessResponse(id, formattedContent);
     } catch (error) {
-      this.logFetch(authContext, url, url, "", Date.now() - startTime, ipAddress, countryCode, 500, "FETCH_FAILED");
+      this.logFetch(
+        authContext,
+        url,
+        url,
+        "",
+        Date.now() - startTime,
+        ipAddress,
+        countryCode,
+        500,
+        "FETCH_FAILED"
+      );
 
       logger.error(
         `Fetch failed for URL ${url}: ${error instanceof Error ? error.message : String(error)}`

--- a/src/mcp/tools/search-tool.ts
+++ b/src/mcp/tools/search-tool.ts
@@ -13,6 +13,7 @@ import {
 import {
   createErrorResponse,
   createSuccessResponse,
+  createToolErrorResponse,
   formatRAGResponse,
 } from "../formatters/response-formatter.js";
 import { APP_CONSTANTS, MCP_ERROR_CODES } from "../protocol-handler.js";
@@ -39,11 +40,10 @@ export class SearchTool {
 
     // Validate query parameter
     if (!query || typeof query !== "string" || query.trim().length === 0) {
-      return createErrorResponse(
-        id,
-        MCP_ERROR_CODES.INVALID_PARAMS,
-        APP_CONSTANTS.MISSING_SEARCH_ERROR
-      );
+      return createToolErrorResponse(id, APP_CONSTANTS.MISSING_SEARCH_ERROR, {
+        errorCode: "INVALID_QUERY",
+        field: "query",
+      });
     }
 
     const requestedQuery = query;

--- a/src/mcp/tools/search-tool.ts
+++ b/src/mcp/tools/search-tool.ts
@@ -80,7 +80,17 @@ export class SearchTool {
       );
 
       if (!rateLimitResult.allowed) {
-        this.logSearch(authContext, requestedQuery, actualQuery, { count: 0 }, 0, clientIP, countryCode, 429, "RATE_LIMIT_EXCEEDED");
+        this.logSearch(
+          authContext,
+          requestedQuery,
+          actualQuery,
+          { count: 0 },
+          0,
+          clientIP,
+          countryCode,
+          429,
+          "RATE_LIMIT_EXCEEDED"
+        );
 
         return createErrorResponse(
           id,
@@ -133,7 +143,15 @@ export class SearchTool {
       result_count: resultCount,
     });
 
-    this.logSearch(authContext, requestedQuery, actualQuery, ragResult, Date.now() - startTime, ipAddress, countryCode);
+    this.logSearch(
+      authContext,
+      requestedQuery,
+      actualQuery,
+      ragResult,
+      Date.now() - startTime,
+      ipAddress,
+      countryCode
+    );
 
     return ragResult;
   }

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,3 +1,4 @@
+name = "apple-rag-mcp"
 main = "dist/src/worker.js"
 compatibility_date = "2024-12-01"
 compatibility_flags = ["nodejs_compat"]


### PR DESCRIPTION
### Motivation
- Accept newer MCP clients without hard-rejecting unknown `protocolVersion` to avoid connectivity breakage while still advertising server capabilities. 
- Make tool input/validation failures return MCP-compliant tool execution errors with machine-readable metadata so clients/models can self-correct. 
- Reflect the newer MCP spec in the manifest and ensure the Worker build configuration parses correctly. 
- Remove implicit SSE fallback surface (server only supports POST) and keep schema dialect modern and typed.

### Description
- Relaxed protocol handling by making `initialize` non-blocking for unknown client `protocolVersion` and logging a warning instead of returning an error (update in `src/mcp/protocol-handler.ts`).
- Replaced the old strict protocol validator by removing `validateProtocolVersion` from `src/mcp/middleware/request-validator.ts` to avoid accidental hard-rejection logic.
- Added structured tool execution error responses via `createToolErrorResponse(requestId, message, data?)` in `src/mcp/formatters/response-formatter.ts` and used it across tool validation and runtime failures.
- Updated tool validation to carry structured `data` metadata (e.g. `errorCode`, `field`) in `src/mcp/middleware/request-validator.ts` and converted tool-argument failures to tool execution errors at the protocol layer.
- Switched `tools/list` to use typed static input schemas with JSON Schema 2020-12 dialect (`SEARCH_INPUT_SCHEMA`, `FETCH_INPUT_SCHEMA`) in `src/mcp/protocol-handler.ts` to fix readonly-array typing and modernize schemas.
- Changed search/fetch handlers to return structured tool errors for invalid inputs and not-found cases (`src/mcp/tools/search-tool.ts`, `src/mcp/tools/fetch-tool.ts`).
- Updated manifest and health metadata to announce `2025-11-25` as protocolVersion and include `serverInfo.description` (`src/mcp/manifest.ts`).
- Adjusted CORS preflight allowed methods to remove `GET` (server only accepts POST) so SSE fallback is not implicitly allowed (`src/mcp/protocol-handler.ts`).
- Fixed Cloudflare worker config parsing by adding `name = "apple-rag-mcp"` to `wrangler.toml`.

### Testing
- Ran `pnpm run build` (TypeScript compilation via `tsc`) after the changes and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69857f22810c8333acc777c4e15d23c9)