### PR TITLE
[codex] Add cached corpus stats endpoint

### DIFF
--- a/src/components/dashboard/StatsCards.tsx
+++ b/src/components/dashboard/StatsCards.tsx
@@ -1,7 +1,10 @@
 import type { Icon } from "@tabler/icons-react";
 import { IconCircleCheck, IconDatabase, IconFileText, IconVideo } from "@tabler/icons-react";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Card, CardContent } from "@/components/ui/Card";
+import { api } from "@/lib/api";
+import type { CorpusStats } from "@/types";
 
 interface StatCard {
 	icon: Icon;
@@ -14,11 +17,41 @@ interface StatCard {
 
 const StatsCards = () => {
 	const { t, i18n } = useTranslation();
+	const [corpusStats, setCorpusStats] = useState<CorpusStats | null>(null);
+
+	useEffect(() => {
+		let isMounted = true;
+
+		api
+			.getCorpusStats()
+			.then((response) => {
+				if (isMounted && response.success && response.data) {
+					setCorpusStats(response.data as CorpusStats);
+				}
+			})
+			.catch(() => {});
+
+		return () => {
+			isMounted = false;
+		};
+	}, []);
+
+	const formatNumber = (value: number | undefined) =>
+		typeof value === "number"
+			? new Intl.NumberFormat(i18n.language === "zh" ? "zh-CN" : "en-US").format(value)
+			: "...";
+
+	const statsDate = corpusStats?.generated_at
+		? new Date(corpusStats.generated_at).toLocaleDateString(
+				i18n.language === "zh" ? "zh-CN" : "en-US",
+				{ year: "numeric", month: "short", day: "numeric" },
+			)
+		: "...";
 
 	const stats: StatCard[] = [
 		{
 			icon: IconFileText,
-			value: "373,608",
+			value: formatNumber(corpusStats?.docs_total),
 			labelKey: "dashboard.stats_doc_pages",
 			color: "#9595ff",
 			clickable: true,
@@ -26,7 +59,7 @@ const StatsCards = () => {
 		},
 		{
 			icon: IconVideo,
-			value: "1,412",
+			value: formatNumber(corpusStats?.videos_total),
 			labelKey: "dashboard.stats_wwdc_videos",
 			color: "#fca147",
 			clickable: true,
@@ -34,14 +67,14 @@ const StatsCards = () => {
 		},
 		{
 			icon: IconDatabase,
-			value: "397,114",
+			value: formatNumber(corpusStats?.chunks_total),
 			labelKey: "dashboard.stats_chunks",
 			color: "#42c16e",
 			clickable: false,
 		},
 		{
 			icon: IconCircleCheck,
-			value: "100%",
+			value: `${corpusStats?.embedded_percentage ?? 100}%`,
 			labelKey: "dashboard.stats_embedded",
 			color: "#dc5bb7",
 			clickable: false,
@@ -53,11 +86,6 @@ const StatsCards = () => {
 			window.open(stat.url, "_blank");
 		}
 	};
-
-	const yesterdayDate = new Date(Date.now() - 24 * 60 * 60 * 1000).toLocaleDateString(
-		i18n.language === "zh" ? "zh-CN" : "en-US",
-		{ year: "numeric", month: "short", day: "numeric" },
-	);
 
 	return (
 		<Card className="mb-6">
@@ -76,7 +104,7 @@ const StatsCards = () => {
 				<div className="text-center mb-5">
 					<h3 className="text-xl font-bold text-light mb-2">{t("dashboard.stats_heading")}</h3>
 					<p className="text-muted text-sm opacity-75">
-						{t("dashboard.stats_date", { date: yesterdayDate })}
+						{t("dashboard.stats_date", { date: statsDate })}
 					</p>
 				</div>
 				<div className="grid grid-cols-2 lg:grid-cols-4 gap-3 lg:gap-4">

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -228,6 +228,10 @@ class ApiClient {
 		return this.get(`/users/usage/stats?period=${period}`);
 	}
 
+	async getCorpusStats() {
+		return this.get("/stats/corpus");
+	}
+
 	async getUsageLogs(limit: number = 20, page: number = 1) {
 		return this.get(`/usage-logs/history?limit=${limit}&page=${page}`);
 	}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -58,6 +58,14 @@ export interface ToolCallsStats {
 	}>;
 }
 
+export interface CorpusStats {
+	docs_total: number;
+	videos_total: number;
+	chunks_total: number;
+	embedded_percentage: 100;
+	generated_at: string;
+}
+
 export interface CurrentUsage {
 	current_usage: number;
 	limit: number;

--- a/worker/api/app.ts
+++ b/worker/api/app.ts
@@ -10,6 +10,7 @@ import authorizedIPsRoutes from "./routes/authorized-ips.js";
 import contactMessagesRoutes from "./routes/contact-messages.js";
 import mcpTokenRoutes from "./routes/mcp-tokens.js";
 import { oauthRoutes } from "./routes/oauth.js";
+import statsRoutes from "./routes/stats.js";
 import stripeRoutes from "./routes/stripe.js";
 import usageLogsRoutes from "./routes/usage-logs.js";
 import userRoutes from "./routes/users.js";
@@ -55,6 +56,7 @@ apiApp.route("/authorized-ips", authorizedIPsRoutes);
 apiApp.route("/usage-logs", usageLogsRoutes);
 apiApp.route("/admin", adminRoutes);
 apiApp.route("/stripe", stripeRoutes);
+apiApp.route("/stats", statsRoutes);
 
 apiApp.get("/", (c) => c.json({ name: "Apple RAG API", version: "2.0.0" }));
 

--- a/worker/api/routes/stats.ts
+++ b/worker/api/routes/stats.ts
@@ -1,0 +1,110 @@
+import postgres from "postgres";
+import { ApiErrorCode } from "../constants/error-codes";
+import { createOpenAPIApp } from "../utils/openapi";
+
+const app = createOpenAPIApp();
+const CACHE_TTL_SECONDS = 3600;
+const APPLE_URL_PATTERN = "https://developer.apple.com/%";
+const VIDEO_URL_PATTERN = "https://developer.apple.com/videos/play/%";
+
+interface CorpusStats {
+	docs_total: number;
+	videos_total: number;
+	chunks_total: number;
+	embedded_percentage: 100;
+	generated_at: string;
+}
+
+function createCacheKey(requestUrl: string): Request {
+	const url = new URL(requestUrl);
+	url.pathname = "/api/stats/corpus";
+	url.search = "";
+	return new Request(url.toString(), { method: "GET" });
+}
+
+function createStatsResponse(data: CorpusStats): Response {
+	return new Response(JSON.stringify({ success: true, data }), {
+		headers: {
+			"Content-Type": "application/json; charset=utf-8",
+			"Cache-Control": `public, max-age=${CACHE_TTL_SECONDS}, s-maxage=${CACHE_TTL_SECONDS}, stale-while-revalidate=300`,
+		},
+	});
+}
+
+app.get("/corpus", async (c) => {
+	const cacheKey = createCacheKey(c.req.url);
+	const cached = await caches.default.match(cacheKey);
+	if (cached) return cached;
+
+	const sql = postgres({
+		host: c.env.RAG_DB_HOST,
+		port: Number.parseInt(c.env.RAG_DB_PORT || "5432", 10),
+		database: c.env.RAG_DB_DATABASE,
+		username: c.env.RAG_DB_USER,
+		password: c.env.RAG_DB_PASSWORD || "",
+		ssl: c.env.RAG_DB_SSLMODE !== "disable",
+		max: 1,
+		idle_timeout: 10,
+		connect_timeout: 10,
+		transform: { undefined: null },
+		onnotice: () => {},
+	});
+
+	try {
+		const rows = await sql`
+			WITH page_counts AS (
+				SELECT
+					COUNT(*) FILTER (
+						WHERE url LIKE ${APPLE_URL_PATTERN}
+						  AND url NOT LIKE ${VIDEO_URL_PATTERN}
+					) AS docs_total,
+					COUNT(*) FILTER (
+						WHERE url LIKE ${VIDEO_URL_PATTERN}
+					) AS videos_total
+				FROM pages
+				WHERE url LIKE ${APPLE_URL_PATTERN}
+			),
+			chunk_counts AS (
+				SELECT COUNT(*) AS chunks_total
+				FROM chunks
+				WHERE url LIKE ${APPLE_URL_PATTERN}
+			)
+			SELECT
+				page_counts.docs_total,
+				page_counts.videos_total,
+				chunk_counts.chunks_total
+			FROM page_counts, chunk_counts
+		`;
+
+		const row = rows[0] || {};
+		const data: CorpusStats = {
+			docs_total: Number(row.docs_total) || 0,
+			videos_total: Number(row.videos_total) || 0,
+			chunks_total: Number(row.chunks_total) || 0,
+			embedded_percentage: 100,
+			generated_at: new Date().toISOString(),
+		};
+
+		const response = createStatsResponse(data);
+		c.executionCtx.waitUntil(caches.default.put(cacheKey, response.clone()));
+		return response;
+	} catch (error) {
+		console.error(
+			`Corpus stats query failed: ${error instanceof Error ? error.message : String(error)}`,
+		);
+		return c.json(
+			{
+				success: false,
+				error: {
+					code: ApiErrorCode.INTERNAL_ERROR,
+					message: "Failed to retrieve corpus statistics",
+				},
+			},
+			500,
+		);
+	} finally {
+		await sql.end().catch(() => {});
+	}
+});
+
+export default app;


### PR DESCRIPTION
## Summary

- Add a public `/api/stats/corpus` endpoint for dashboard corpus statistics.
- Query only the dashboard-required totals: docs, WWDC videos, and chunks.
- Cache successful responses with Cloudflare Cache API for one hour.
- Update dashboard stats cards to consume the endpoint and keep Embedded fixed at 100%.

## Why

The dashboard stats were hardcoded, so they drifted from collector output. The new endpoint provides live corpus totals while avoiding uncontrolled PostgreSQL query volume through Worker-side read-through caching.

## Validation

- `pnpm check`